### PR TITLE
Imported module from a prior sketch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,195 @@
 # Dropwizard MyBatis Support
 
 [![Build Status](https://circleci.com/gh/login-box/dropwizard-mybatis.svg)](https://circleci.com/gh/login-box/dropwizard-mybatis)
+
+## Defining Mapper Interfaces
+
+A mapper interface defines methods that map to SQL queries or procedure calls.
+For example, an interface for managing users might look like
+
+```java
+package com.example.helloworld.mappers;
+
+public interface UsersMapper {
+    User findByUsername(@Param("username") String username);
+
+    void addUser(@Param("user") User user);
+}
+```
+
+MyBatis binds these interfaces to actual SQL stored in a mapper config file in
+the same package. In this case, `UsersMapper.xml` would look like this:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.helloworld.mappers.UsersMapper">
+    <select id="findByUsername" resultType="User">
+    <![CDATA[
+        select username, email
+        from users
+        where username = #{username}
+    ]]>
+    </select>
+
+    <resultMap id="User" type="com.example.helloworld.mappers.User">
+        <id column="username" property="username" />
+        <result column="email" property="email" />
+    </resultMap>
+
+    <insert id="addUser">
+    <![CDATA[
+        insert into users (username, email)
+        values (#{user.username}, #{user.email})
+    ]]>
+    </insert>
+</mapper>
+```
+
+See the [MyBatis
+documentation](http://mybatis.github.io/mybatis-3/sqlmap-xml.html) for more
+thorough examples, covering things like nested results and complex relational
+mapping for joins.
+
+## Configuring The Database
+
+Before you can use MyBatis in your Dropwizard app, you'll need to configure a
+database connection pool in your application configuration class:
+
+```java
+package com.example.helloworld;
+
+/* imports */
+
+public class HelloWorldConfiguration extends Configuration {
+    @Valid
+    @NotNull
+    private DataSourceFactory dataSourceFactory = new DataSourceFactory();
+
+    @JsonProperty("database")
+    public DataSourceFactory getDataSourceFactory() {
+        return this.dataSourceFactory;
+    }
+}
+```
+
+You can configure the database connection in your config file:
+
+```yaml
+database:
+    # the name of your JDBC driver
+    driverClass: org.postgresql.Driver
+
+    # the username
+    user: pg-user
+
+    # the password
+    password: iAMs00perSecrEET
+
+    # the JDBC URL
+    url: jdbc:postgresql://db.example.com/db-prod
+
+    # any properties specific to your JDBC driver:
+    properties:
+        charSet: UTF-8
+
+    # the maximum amount of time to wait on an empty pool before throwing an exception
+    maxWaitForConnection: 1s
+
+    # the SQL query to run when validating a connection's liveness
+    validationQuery: "/* MyService Health Check */ SELECT 1"
+
+    # the timeout before a connection validation queries fail
+    validationQueryTimeout: 3s
+
+    # the minimum number of connections to keep open
+    minSize: 8
+
+    # the maximum number of connections to keep open
+    maxSize: 32
+
+    # whether or not idle connections should be validated
+    checkConnectionWhileIdle: false
+
+    # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
+    evictionInterval: 10s
+
+    # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
+    minIdleTime: 1 minute
+```
+
+## Adding MyBatis To Your App
+
+Once your database connection is configured, you can register a `MybatisBundle`
+during your application's bootstrap. I strongly recommend storing the bundle in
+a `private final` attribute on your application class, for later use:
+
+```java
+package com.example.helloworld;
+
+public class HelloWorld extends Application<HelloWorldConfiguration> {
+
+    public static void main(String... args) throws Exception {
+        new HelloWorld().run(args);
+    }
+
+    private final MybatisBundle<HelloWorldConfiguration> mybatisBundle
+            = new MybatisBundle<HelloWorldConfiguration>("com.example.helloworld") {
+        @Override
+        public DataSourceFactory getDataSourceFactory(HelloWorldConfiguration configuration) {
+            return configuration.getDataSourceFactory();
+        }
+    };
+
+    @Override
+    public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
+        bootstrap.addBundle(mybatisBundle);
+    }
+    // . . .
+}
+```
+
+You can use MyBatis from your resource classes by calling
+`getSqlSessionFactory()` on the bundle to get its session factory:
+
+```java
+    public void run(HelloWorldConfiguration configuration, Environment environment) throws Exception {
+        SqlSessionFactory sessionFactory = mybatisBundle.getSqlSessionFactory();
+        environment.jersey().register(new ExampleResource(sessionFactory));
+        // . . .
+    }
+```
+
+The `SqlSessionFactory` will only be available after `initialize` completes.
+
+## Making Database Calls
+
+Your resources can use the `SqlSessionFactory`'s `openSession()` methods to
+begin database conversations:
+
+```
+package com.example.helloworld.resources;
+
+@Path("/user/{username}")
+public class ExampleResource {
+    private final SqlSessionFactory sessionFactory;
+
+    public ExampleResource(SqlSessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @GET
+    public User getUser(@PathParam("username") String username) {
+        try (SqlSession session = sessionFactory.openSession()) {
+            UsersMapper users = session.getMapper(UsersMapper.class);
+            return users.findByUsername(username);
+        }
+    }
+}
+```
+
+_At present_, `MybatisBundle` doesn't provide any kind of automated transaction
+management. Applications are responsible for demarcating their own transactions
+using the session's `commit()` and `rollback()` methods.

--- a/build.gradle
+++ b/build.gradle
@@ -20,3 +20,26 @@ sourceCompatibility = '1.8'
 release {
     grgit = Grgit.open(projectDir)
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    ext {
+        dropwizardVersion = '0.8.0'
+
+        mybatisVersion = '3.2.8'
+
+        hamcrestVersion = '1.3'
+    }
+
+    compile group: 'io.dropwizard', name: 'dropwizard-db', version: dropwizardVersion
+
+    compile group: 'org.mybatis', name: 'mybatis', version: mybatisVersion
+
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrestVersion
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrestVersion
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
+}

--- a/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
@@ -1,0 +1,232 @@
+package com.loginbox.dropwizard.mybatis;
+
+import com.loginbox.dropwizard.mybatis.healthchecks.SqlSessionFactoryHealthCheck;
+import com.loginbox.dropwizard.mybatis.mappers.Ping;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.DatabaseConfiguration;
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.setup.Bootstrap;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Provides the MyBatis persistence framework to your Dropwizard app.
+ * <p>
+ * To use this bundle, first, add a {@link io.dropwizard.db.DataSourceFactory} to your configuration class:
+ * <pre>
+ * public class HelloWorldConfiguration extends Configuration {
+ *    {@literal @}Valid
+ *    {@literal @}NotNull
+ *     private DataSourceFactory dataSourceFactory = new DataSourceFactory();
+ *
+ *    {@literal @}JsonProperty("database")
+ *     public DataSourceFactory getDataSourceFactory() {
+ *         return this.dataSourceFactory;
+ *     }
+ * }
+ * </pre>
+ * Then, register an instance of this bundle in your app's {@link io.dropwizard.Application#initialize(io.dropwizard.setup.Bootstrap)}
+ * method:
+ * <pre>
+ * public class HelloWorld extends Application&lt;HelloWorldConfiguration&gt; {
+ *
+ *     public static void main(String... args) throws Exception {
+ *         new HelloWorld().run(args);
+ *     }
+ *
+ *     private final MybatisBundle&lt;HelloWorldConfiguration&gt; mybatisBundle
+ *             = new MybatisBundle&lt;HelloWorldConfiguration&gt;("com.example.helloworld") {
+ *        {@literal @}Override
+ *         public DataSourceFactory getDataSourceFactory(HelloWorldConfiguration configuration) {
+ *             return configuration.getDataSourceFactory();
+ *         }
+ *     };
+ *
+ *    {@literal @}Override
+ *     public void initialize(Bootstrap&lt;HelloWorldConfiguration&gt; bootstrap) {
+ *         bootstrap.addBundle(mybatisBundle);
+ *     }
+ *     // . . .
+ * }
+ * </pre>
+ * This will automatically scan the named package(s) for MyBatis mapper {@code .xml} files and interfaces. It will also
+ * register a {@link com.loginbox.dropwizard.mybatis.healthchecks.SqlSessionFactoryHealthCheck health check} for your
+ * database pool, which you can monitor via the health checks admin endpoint.
+ * <p>
+ * To use MyBatis in your app, once configured, call {@link #getSqlSessionFactory()} in your own app's {@link
+ * io.dropwizard.Application#run(io.dropwizard.Configuration, io.dropwizard.setup.Environment)} method:
+ * <pre>
+ *    {@literal @}Override
+ *     public void run(HelloWorldConfiguration configuration, Environment environment) throws Exception {
+ *         SqlSessionFactory sessionFactory = mybatisBundle.getSqlSessionFactory();
+ *         environment.jersey().register(new ExampleResource(sessionFactory));
+ *         // . . .
+ *     }
+ * </pre>
+ * <p>
+ * There are three ways to configure MyBatis, depending on your needs: <ul> <li>The {@link #MybatisBundle(Class,
+ * Class...)} constructor accepts an explicit list of mapper interfaces to configure. The corresponding SQL can be stored
+ * in annotations on the mapper interfaces themselves, or in correspondingly-named {@code .xml} files in the same
+ * package. For example, {@code com.example.mappers.Users} would correspond with the file {@code
+ * com/example/mappers/Users.xml}.</li> <li>The {@link #MybatisBundle(String, String...)} constructor accepts a list of
+ * packages to scan. Any mapper interfaces defined in these packages <em>or subpackages of these packages</em> will be
+ * detected and configured. As with the explicit case, SQL for mappers can be stored in the mapper interface itself, or
+ * in XML files.</li> <li>In either of the above cases, or using the {@link #MybatisBundle()} constructor, you can
+ * optionally override the {@link #configureMybatis(org.apache.ibatis.session.Configuration)} method to customize the
+ * Mybatis configuration yourself.</li> </ul>
+ *
+ * @param <T>
+ *         Your application's configuration class.
+ */
+public abstract class MybatisBundle<T extends io.dropwizard.Configuration> implements ConfiguredBundle<T>, DatabaseConfiguration<T> {
+    private static final String DEFAULT_NAME = "mybatis";
+
+    private final String name = DEFAULT_NAME;
+    private SqlSessionFactory sqlSessionFactory = null;
+
+    private final Consumer<Configuration> configureCallback;
+
+    /**
+     * Creates a bundle with no mappers configured automatically. The bundle's Mybatis {@link
+     * org.apache.ibatis.session.SqlSessionFactory} can still be configured by overriding {@link
+     * #configureMybatis(org.apache.ibatis.session.Configuration)}.
+     */
+    public MybatisBundle() {
+        this.configureCallback = config -> {
+        };
+    }
+
+    /**
+     * Creates a bundle with an explicit list of mapper interfaces. The bundle's Mybatis {@link
+     * org.apache.ibatis.session.SqlSessionFactory} can be further configured by overriding {@link
+     * #configureMybatis(org.apache.ibatis.session.Configuration)}.
+     *
+     * @param mapper
+     *         the first mapper to register.
+     * @param mappers
+     *         the remaining mappers to register.
+     */
+    // The wonky signature avoids ambiguity with the () and (String...) cases.
+    public MybatisBundle(Class<?> mapper, Class<?>... mappers) {
+        this.configureCallback = configure(Configuration::addMapper, mapper, mappers);
+    }
+
+    /**
+     * Creates a bundle by scanning packages for mappers to configure. Mybatis will automatically scan subpackages of
+     * the named packages. The bundle's Mybatis {@link org.apache.ibatis.session.SqlSessionFactory} can be further
+     * configured by overriding {@link #configureMybatis(org.apache.ibatis.session.Configuration)}.
+     *
+     * @param packageName
+     *         the first package to scan.
+     * @param packageNames
+     *         the remaining packages to scan.
+     */
+    // The wonky signature avoids ambiguity with the () and (Class...) cases.
+    public MybatisBundle(String packageName, String... packageNames) {
+        this.configureCallback = configure(Configuration::addMappers, packageName, packageNames);
+    }
+
+    /**
+     * Returns the {@link org.apache.ibatis.session.SqlSessionFactory} created by this bundle. Until {@link
+     * #run(io.dropwizard.Configuration, io.dropwizard.setup.Environment)} completes, this will return
+     * <code>null</code>.
+     * <p>
+     * Care is needed when using this bundle in other bundles: this method will return null throughout the
+     * <code>initialize</code> phase of Dropwizard's startup. It's generally better to pass this whole bundle to its
+     * dependents, and let them obtain session factories at the appropriate time, than it is to take the session factory
+     * from this bundle and pass it to other bundles. This awkwardness is inherent in MyBatis' design.
+     *
+     * @return the configured session factory for this bundle, or <code>null</code> if the bundle hasn't been started
+     * yet.
+     */
+    @Nullable
+    public SqlSessionFactory getSqlSessionFactory() {
+        return sqlSessionFactory;
+    }
+
+    /**
+     * Does nothing on its own, but may be overridden to customize Mybatis configuration more flexibly.
+     * <p>
+     * This will be called <em>after</em> <ol> <li>the bundle's own mappers and other objects have been registered in
+     * the configuration, and</li> <li>any mappers or packages from the constructor have been registered in the
+     * configuration.</li> </ol>
+     *
+     * @param configuration
+     *         the MyBatis configuration in flight.
+     * @throws Exception
+     *         if the custom configuration fails. This will be thrown out through {@link
+     *         #run(io.dropwizard.Configuration, io.dropwizard.setup.Environment)}, which will normally abort
+     *         application startup.
+     */
+    protected void configureMybatis(Configuration configuration) throws Exception {
+    }
+
+    /**
+     * Creates the bundle's MyBatis session factory and registers health checks.
+     *
+     * @param configuration
+     *         the application's configuration.
+     * @param environment
+     *         the Dropwizard environment being started.
+     * @throws Exception
+     *         if MyBatis setup fails for any reason. MyBatis exceptions will be thrown as-is.
+     */
+    @Override
+    public void run(T configuration, io.dropwizard.setup.Environment environment) throws Exception {
+        ManagedDataSource dataSource = buildDataSource(configuration, environment);
+        environment.lifecycle().manage(dataSource);
+
+        sqlSessionFactory = createSqlSessionFactory(dataSource);
+
+        environment.healthChecks().register(name, new SqlSessionFactoryHealthCheck(sqlSessionFactory));
+    }
+
+    private SqlSessionFactory createSqlSessionFactory(DataSource dataSource) throws Exception {
+        Configuration mybatisConfiguration = buildMybatisConfiguration(dataSource);
+        return new SqlSessionFactoryBuilder().build(mybatisConfiguration);
+    }
+
+    private Configuration buildMybatisConfiguration(DataSource dataSource) throws Exception {
+        TransactionFactory transactionFactory = new JdbcTransactionFactory();
+        Environment mybatisEnvironment = new Environment(name, transactionFactory, dataSource);
+        Configuration configuration = new Configuration(mybatisEnvironment);
+        configuration.addMapper(Ping.class);
+        configureCallback.accept(configuration);
+        configureMybatis(configuration);
+        return configuration;
+    }
+
+    private ManagedDataSource buildDataSource(T configuration, io.dropwizard.setup.Environment environment) {
+        DataSourceFactory dataSourceFactory = getDataSourceFactory(configuration);
+        return dataSourceFactory.build(environment.metrics(), name);
+    }
+
+    private <T> Consumer<Configuration> configure(BiConsumer<Configuration, T> valueApplicator, T value, T... values) {
+        return (configuration) -> {
+            valueApplicator.accept(configuration, value);
+            for (T v : values) {
+                valueApplicator.accept(configuration, v);
+            }
+        };
+    }
+
+    /**
+     * Initializes the bundle by doing nothing.
+     *
+     * @param bootstrap
+     *         the Dropwizard bootstrap configuration.
+     */
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+    }
+}

--- a/src/main/java/com/loginbox/dropwizard/mybatis/healthchecks/SqlSessionFactoryHealthCheck.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/healthchecks/SqlSessionFactoryHealthCheck.java
@@ -1,0 +1,30 @@
+package com.loginbox.dropwizard.mybatis.healthchecks;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.loginbox.dropwizard.mybatis.mappers.Ping;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+
+/**
+ * {@link com.loginbox.dropwizard.mybatis.mappers.Ping}s the database to check its health. Any non-exceptional response,
+ * in any amount of time, is treated as a healthy response. Any exceptional response is treated as an unhealthy
+ * response.
+ */
+public class SqlSessionFactoryHealthCheck extends HealthCheck {
+    private final SqlSessionFactory sqlSessionFactory;
+
+    public SqlSessionFactoryHealthCheck(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            Ping mapper = session.getMapper(Ping.class);
+            mapper.ping();
+            return Result.healthy();
+        } catch (Exception e) {
+            return Result.unhealthy(e);
+        }
+    }
+}

--- a/src/main/java/com/loginbox/dropwizard/mybatis/mappers/Ping.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/mappers/Ping.java
@@ -1,0 +1,17 @@
+package com.loginbox.dropwizard.mybatis.mappers;
+
+/**
+ * Provides a simple read-only query to test database connectivity. This query touches no tables.
+ * <p>
+ * By default, the mapper runs {@code SELECT 1} to verify that the database is reachable. Applications can override this
+ * query by providing their own copy of the mapper configuration file {@code Ping.xml}, in this package. This may be
+ * necessary on database management systems such as Oracle, which do not allow queries to omit the {@code FROM} clause.
+ */
+public interface Ping {
+    /**
+     * Pings the database.
+     *
+     * @return a meaningless value.
+     */
+    public int ping();
+}

--- a/src/main/resources/com/loginbox/dropwizard/mybatis/mappers/Ping.xml
+++ b/src/main/resources/com/loginbox/dropwizard/mybatis/mappers/Ping.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.loginbox.dropwizard.mybatis.mappers.Ping">
+    <select id="ping" resultType="_int">
+        select 1
+    </select>
+</mapper>

--- a/src/test/java/com/loginbox/dropwizard/mybatis/MybatisBundleTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/MybatisBundleTest.java
@@ -1,0 +1,143 @@
+package com.loginbox.dropwizard.mybatis;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.loginbox.dropwizard.mybatis.healthchecks.SqlSessionFactoryHealthCheck;
+import com.loginbox.dropwizard.mybatis.mappers.Ping;
+import com.loginbox.dropwizard.mybatis.testMappers.ExampleMapper;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Bootstrap;
+import org.apache.ibatis.session.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import static com.loginbox.dropwizard.mybatis.matchers.ConfigurationMapperMatcher.hasMapper;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MybatisBundleTest {
+    private final DataSourceFactory dataSourceFactory = mock(DataSourceFactory.class);
+    private final Bootstrap<io.dropwizard.Configuration> bootstrap = mock(Bootstrap.class);
+    private final io.dropwizard.Configuration configuration = mock(io.dropwizard.Configuration.class);
+    private final io.dropwizard.setup.Environment environment = mock(io.dropwizard.setup.Environment.class);
+    private final ManagedDataSource dataSource = mock(ManagedDataSource.class);
+    private final LifecycleEnvironment lifecycle = mock(LifecycleEnvironment.class);
+    private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
+
+    private class TestMybatisBundle<T extends io.dropwizard.Configuration>
+            extends MybatisBundle<T> {
+        public TestMybatisBundle() {
+            super();
+        }
+
+        public TestMybatisBundle(Class<?> mapper, Class<?>... mappers) {
+            super(mapper, mappers);
+        }
+
+        public TestMybatisBundle(String packageName, String... packageNames) {
+            super(packageName, packageNames);
+        }
+
+        @Override
+        public DataSourceFactory getDataSourceFactory(io.dropwizard.Configuration configuration) {
+            return dataSourceFactory;
+        }
+    }
+
+    @Before
+    public void wireMocks() {
+        when(environment.lifecycle()).thenReturn(lifecycle);
+        when(environment.healthChecks()).thenReturn(healthChecks);
+
+        when(dataSourceFactory.build(Matchers.any(), Matchers.any())).thenReturn(dataSource);
+    }
+
+    @Test
+    public void managesDataSource() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        verify(lifecycle).manage(dataSource);
+    }
+
+    @Test
+    public void usesDataSource() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        assertThat(bundle.getSqlSessionFactory().getConfiguration().getEnvironment().getDataSource(), is(dataSource));
+    }
+
+    @Test
+    public void registersHealthChecks() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        verify(healthChecks).register(anyString(), isA(SqlSessionFactoryHealthCheck.class));
+    }
+
+    @Test
+    public void registersInterfaces() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>(ExampleMapper.class);
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
+
+        assertThat(configuration, hasMapper(ExampleMapper.class));
+    }
+
+    @Test
+    public void registersPackages() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>("com.loginbox.dropwizard.mybatis.testMappers");
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
+
+        assertThat(configuration, hasMapper(ExampleMapper.class));
+    }
+
+    @Test
+    public void registersPingMapper() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
+
+        assertThat(configuration, hasMapper(Ping.class));
+    }
+
+    @Test
+    public void appliesCustomConfiguration() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle = new TestMybatisBundle<io.dropwizard.Configuration>(ExampleMapper.class) {
+            @Override
+            protected void configureMybatis(Configuration configuration) {
+                configuration.setDatabaseId("--test-value--");
+            }
+        };
+
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
+        assertThat(configuration.getDatabaseId(), is("--test-value--"));
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/healthchecks/SqlSessionFactoryHealthCheckTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/healthchecks/SqlSessionFactoryHealthCheckTest.java
@@ -1,0 +1,56 @@
+package com.loginbox.dropwizard.mybatis.healthchecks;
+
+import com.loginbox.dropwizard.mybatis.mappers.Ping;
+import org.apache.ibatis.binding.BindingException;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.junit.Test;
+
+import static com.loginbox.dropwizard.mybatis.healthchecks.matchers.HealthyResultMatcher.healthyResult;
+import static com.loginbox.dropwizard.mybatis.healthchecks.matchers.UnhealthyResultMatcher.unhealthyResult;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SqlSessionFactoryHealthCheckTest {
+
+    private final SqlSessionFactory sqlSessionFactory = mock(SqlSessionFactory.class);
+    private final SqlSession session = mock(SqlSession.class);
+    private final Ping mapper = mock(Ping.class);
+    private final SqlSessionFactoryHealthCheck healthCheck = new SqlSessionFactoryHealthCheck(sqlSessionFactory);
+
+    @Test
+    public void healthy() throws Exception {
+        when(sqlSessionFactory.openSession()).thenReturn(session);
+        when(session.getMapper(Ping.class)).thenReturn(mapper);
+        when(mapper.ping()).thenReturn(37);
+        assertThat(healthCheck.check(), is(healthyResult()));
+    }
+
+    @Test
+    public void unhealthyWhenOpenSessionFails() throws Exception {
+        RuntimeException e = new RuntimeException();
+        when(sqlSessionFactory.openSession()).thenThrow(e);
+        assertThat(healthCheck.check(), is(unhealthyResult(e)));
+    }
+
+    @Test
+    public void unhealthyWhenMapperAbsent() throws Exception {
+        BindingException e = new BindingException();
+        when(sqlSessionFactory.openSession()).thenReturn(session);
+        when(session.getMapper(Ping.class)).thenThrow(e);
+        assertThat(healthCheck.check(), is(unhealthyResult(e)));
+    }
+
+    @Test
+    public void unhealthyWhenPingFails() throws Exception {
+        RuntimeException e = new RuntimeException();
+        when(sqlSessionFactory.openSession()).thenReturn(session);
+        when(session.getMapper(Ping.class)).thenReturn(mapper);
+        when(mapper.ping()).thenThrow(e);
+        assertThat(healthCheck.check(), is(unhealthyResult(e)));
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/healthchecks/matchers/HealthyResultMatcher.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/healthchecks/matchers/HealthyResultMatcher.java
@@ -1,0 +1,36 @@
+package com.loginbox.dropwizard.mybatis.healthchecks.matchers;
+
+import com.codahale.metrics.health.HealthCheck;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class HealthyResultMatcher extends TypeSafeDiagnosingMatcher<HealthCheck.Result> {
+    @Factory
+    public static HealthyResultMatcher healthyResult() {
+        return new HealthyResultMatcher();
+    }
+
+    @Override
+    protected boolean matchesSafely(HealthCheck.Result item, Description mismatchDescription) {
+        if (item == null) {
+            mismatchDescription
+                    .appendText("null");
+            return false;
+        }
+
+        if (!item.isHealthy()) {
+            mismatchDescription
+                    .appendText("unhealthy result: ")
+                    .appendValue(item);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a healthy result");
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/healthchecks/matchers/UnhealthyResultMatcher.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/healthchecks/matchers/UnhealthyResultMatcher.java
@@ -1,0 +1,53 @@
+package com.loginbox.dropwizard.mybatis.healthchecks.matchers;
+
+import com.codahale.metrics.health.HealthCheck;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Objects;
+
+public class UnhealthyResultMatcher extends TypeSafeDiagnosingMatcher<HealthCheck.Result> {
+    private final Throwable expectedError;
+
+    public UnhealthyResultMatcher(Throwable expectedError) {
+        this.expectedError = expectedError;
+    }
+
+    @Factory
+    public static UnhealthyResultMatcher unhealthyResult(Throwable expectedError) {
+        return new UnhealthyResultMatcher(expectedError);
+    }
+
+    @Override
+    protected boolean matchesSafely(HealthCheck.Result item, Description mismatchDescription) {
+        if (item == null) {
+            mismatchDescription
+                    .appendText("null");
+            return false;
+        }
+
+        if (item.isHealthy()) {
+            mismatchDescription
+                    .appendText("healthy result: ")
+                    .appendValue(item);
+            return false;
+        }
+
+        if (!Objects.equals(expectedError, item.getError())) {
+            mismatchDescription
+                    .appendText("unhealthy result with error: ")
+                    .appendValue(item.getError());
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description
+                .appendText("unhealthy result with error: ")
+                .appendValue(expectedError);
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/matchers/ConfigurationMapperMatcher.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/matchers/ConfigurationMapperMatcher.java
@@ -1,0 +1,49 @@
+package com.loginbox.dropwizard.mybatis.matchers;
+
+import org.apache.ibatis.binding.MapperRegistry;
+import org.apache.ibatis.session.Configuration;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class ConfigurationMapperMatcher extends TypeSafeDiagnosingMatcher<Configuration> {
+    private final Class<?> expectedMapper;
+
+    @Factory
+    public static ConfigurationMapperMatcher hasMapper(Class<?> expectedMapper) {
+        return new ConfigurationMapperMatcher(expectedMapper);
+    }
+
+    public ConfigurationMapperMatcher(Class<?> expectedMapper) {
+        this.expectedMapper = expectedMapper;
+    }
+
+    @Override
+    protected boolean matchesSafely(Configuration item, Description mismatchDescription) {
+        if (item == null) {
+            mismatchDescription.appendText("was null");
+            return false;
+        }
+
+        MapperRegistry mapperRegistry = item.getMapperRegistry();
+        if (mapperRegistry == null) {
+            mismatchDescription.appendText("had no mapper registry");
+            return false;
+        }
+
+        if (!mapperRegistry.hasMapper(expectedMapper)) {
+            mismatchDescription
+                    .appendText("had mappers: ")
+                    .appendValueList("[", ", ", "]", mapperRegistry.getMappers());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description
+                .appendText("has mapper: ")
+                .appendValue(expectedMapper);
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/testMappers/ExampleMapper.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/testMappers/ExampleMapper.java
@@ -1,0 +1,4 @@
+package com.loginbox.dropwizard.mybatis.testMappers;
+
+public interface ExampleMapper {
+}


### PR DESCRIPTION
`MybatisBundle` provides a fairly conventional module, broadly inspired by
`dropwizard-hibernate`'s `HibernateBundle`. It provides a session factory once
started, which can in turn be used to obtain mappers. We permit multiple
configuration styles, which overlap:

* Configure nothing.
* Configure an explicit set of mapper interfaces.
* Configure all mappers found in a given set of packages + subpackages.
* Apply arbitrary code to the `Configuration` object.

This should cover the majority of use cases: it certainly covers mine.

There's no support _yet_ for things like automated query decoration for
traceability or annotation-driven transaction demarcation. Those are probably
good ideas, but are considerably more complex to build and I wanted to get
something out fast to iterate on.

As is Right and Just, registering the bundle also registers a healthcheck for
the underlying database.