### PR TITLE
Add support for `null` JdbcType in the Optional handlers.

### DIFF
--- a/src/main/java/com/loginbox/dropwizard/mybatis/types/OptionalTypeHandler.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/types/OptionalTypeHandler.java
@@ -8,6 +8,7 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 
 /**
  * Maps Optional-like types to JDBC.
@@ -29,20 +30,23 @@ import java.sql.SQLException;
  */
 public abstract class OptionalTypeHandler<T> implements TypeHandler<T> {
     @Override
-    public void setParameter(PreparedStatement ps, int i, T parameter, JdbcType jdbcType) throws SQLException {
+    public void setParameter(
+            PreparedStatement ps, int i, @Nullable T parameter, @Nullable JdbcType jdbcType) throws SQLException {
+        int typeCode = jdbcType == null ? Types.OTHER : jdbcType.TYPE_CODE;
+
         if (parameter == null) {
-            ps.setNull(i, jdbcType.TYPE_CODE);
+            ps.setNull(i, typeCode);
             return;
         }
 
         Object rawParameter = unpackOptional(parameter);
         if (rawParameter == null) {
-            ps.setNull(i, jdbcType.TYPE_CODE);
+            ps.setNull(i, typeCode);
             return;
         }
 
         assert rawParameter != null;
-        ps.setObject(i, rawParameter, jdbcType.TYPE_CODE);
+        ps.setObject(i, rawParameter, typeCode);
     }
 
     @Override

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/GuavaOptionalTypeHandlerTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/GuavaOptionalTypeHandlerTest.java
@@ -20,42 +20,6 @@ public class GuavaOptionalTypeHandlerTest {
     private final GuavaOptionalTypeHandler handler = new GuavaOptionalTypeHandler();
 
     @Test
-    public void setsValue() throws SQLException {
-        PreparedStatement ps = mock(PreparedStatement.class);
-        int index = 5;
-        Optional<Object> value = Optional.of("Hello");
-        JdbcType jdbcType = JdbcType.VARCHAR;
-
-        handler.setParameter(ps, index, value, jdbcType);
-
-        verify(ps).setObject(index, "Hello", Types.VARCHAR);
-    }
-
-    @Test
-    public void setsEmpty() throws SQLException {
-        PreparedStatement ps = mock(PreparedStatement.class);
-        int index = 5;
-        Optional<Object> value = Optional.absent();
-        JdbcType jdbcType = JdbcType.VARCHAR;
-
-        handler.setParameter(ps, index, value, jdbcType);
-
-        verify(ps).setNull(index, Types.VARCHAR);
-    }
-
-    @Test
-    public void setsNull() throws SQLException {
-        PreparedStatement ps = mock(PreparedStatement.class);
-        int index = 5;
-        Optional<Object> value = null;
-        JdbcType jdbcType = JdbcType.VARCHAR;
-
-        handler.setParameter(ps, index, value, jdbcType);
-
-        verify(ps).setNull(index, Types.VARCHAR);
-    }
-
-    @Test
     public void readsNonNullResultByIndex() throws SQLException {
         ResultSet rs = mock(ResultSet.class);
         int index = 5;

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/Java8OptionalTypeHandlerTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/Java8OptionalTypeHandlerTest.java
@@ -20,42 +20,6 @@ public class Java8OptionalTypeHandlerTest {
     private final Java8OptionalTypeHandler handler = new Java8OptionalTypeHandler();
 
     @Test
-    public void setsValue() throws SQLException {
-        PreparedStatement ps = mock(PreparedStatement.class);
-        int index = 5;
-        Optional<Object> value = Optional.of("Hello");
-        JdbcType jdbcType = JdbcType.VARCHAR;
-
-        handler.setParameter(ps, index, value, jdbcType);
-
-        verify(ps).setObject(index, "Hello", Types.VARCHAR);
-    }
-
-    @Test
-    public void setsEmpty() throws SQLException {
-        PreparedStatement ps = mock(PreparedStatement.class);
-        int index = 5;
-        Optional<Object> value = Optional.empty();
-        JdbcType jdbcType = JdbcType.VARCHAR;
-
-        handler.setParameter(ps, index, value, jdbcType);
-
-        verify(ps).setNull(index, Types.VARCHAR);
-    }
-
-    @Test
-    public void setsNull() throws SQLException {
-        PreparedStatement ps = mock(PreparedStatement.class);
-        int index = 5;
-        Optional<Object> value = null;
-        JdbcType jdbcType = JdbcType.VARCHAR;
-
-        handler.setParameter(ps, index, value, jdbcType);
-
-        verify(ps).setNull(index, Types.VARCHAR);
-    }
-
-    @Test
     public void readsNonNullResultByIndex() throws SQLException {
         ResultSet rs = mock(ResultSet.class);
         int index = 5;

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/guava/SetNullParameterByIndexTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/guava/SetNullParameterByIndexTest.java
@@ -1,0 +1,54 @@
+package com.loginbox.dropwizard.mybatis.types.optional.guava;
+
+import com.google.common.base.Optional;
+import com.loginbox.dropwizard.mybatis.types.GuavaOptionalTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class SetNullParameterByIndexTest {
+    @Parameters(name = "setParameter(..., {0}, {1}) binds to setNull(..., {2})")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {Optional.absent(), JdbcType.VARCHAR, Types.VARCHAR},
+                {Optional.absent(), JdbcType.INTEGER, Types.INTEGER},
+                {Optional.absent(), null, Types.OTHER},
+                {null, JdbcType.VARCHAR, Types.VARCHAR},
+                {null, JdbcType.INTEGER, Types.INTEGER},
+                {null, null, Types.OTHER},
+        });
+    }
+
+    private final PreparedStatement ps = mock(PreparedStatement.class);
+    private final GuavaOptionalTypeHandler handler = new GuavaOptionalTypeHandler();
+
+    private final Optional<Object> domainValue;
+    private final JdbcType jdbcType;
+    private final int statementType;
+
+    public SetNullParameterByIndexTest(Optional<Object> domainValue, JdbcType jdbcType, int statementType) {
+        this.domainValue = domainValue;
+        this.jdbcType = jdbcType;
+        this.statementType = statementType;
+    }
+
+    @Test
+    public void setsParametersAsExpected() throws SQLException {
+        int index = 5;
+
+        handler.setParameter(ps, index, domainValue, jdbcType);
+        verify(ps).setNull(index, statementType);
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/guava/SetParameterByIndexTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/guava/SetParameterByIndexTest.java
@@ -1,0 +1,55 @@
+package com.loginbox.dropwizard.mybatis.types.optional.guava;
+
+import com.loginbox.dropwizard.mybatis.types.GuavaOptionalTypeHandler;
+import com.loginbox.dropwizard.mybatis.types.Java8OptionalTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.google.common.base.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class SetParameterByIndexTest {
+    @Parameters(name = "setParameter(..., {0}, {1}) binds to setObject(..., {2}, {3})")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {Optional.of("Hello"), JdbcType.VARCHAR, "Hello", Types.VARCHAR},
+                {Optional.of(5), JdbcType.INTEGER, 5, Types.INTEGER},
+                {Optional.of("Hello"), null, "Hello", Types.OTHER},
+        });
+    }
+
+    private final PreparedStatement ps = mock(PreparedStatement.class);
+    private final GuavaOptionalTypeHandler handler = new GuavaOptionalTypeHandler();
+
+    private final Optional<Object> domainValue;
+    private final JdbcType jdbcType;
+    private final Object statementValue;
+    private final int statementType;
+
+    public SetParameterByIndexTest(Optional<Object> domainValue, JdbcType jdbcType, Object statementValue, int statementType) {
+        this.domainValue = domainValue;
+        this.jdbcType = jdbcType;
+        this.statementValue = statementValue;
+        this.statementType = statementType;
+    }
+
+    @Test
+    public void setsParametersAsExpected() throws SQLException {
+        int index = 5;
+
+        handler.setParameter(ps, index, domainValue, jdbcType);
+        verify(ps).setObject(index, statementValue, statementType);
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/java8/SetNullParameterByIndexTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/java8/SetNullParameterByIndexTest.java
@@ -1,0 +1,55 @@
+package com.loginbox.dropwizard.mybatis.types.optional.java8;
+
+import com.loginbox.dropwizard.mybatis.types.GuavaOptionalTypeHandler;
+import com.loginbox.dropwizard.mybatis.types.Java8OptionalTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class SetNullParameterByIndexTest {
+    @Parameters(name = "setParameter(..., {0}, {1}) binds to setNull(..., {2})")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {Optional.empty(), JdbcType.VARCHAR, Types.VARCHAR},
+                {Optional.empty(), JdbcType.INTEGER, Types.INTEGER},
+                {Optional.empty(), null, Types.OTHER},
+                {null, JdbcType.VARCHAR, Types.VARCHAR},
+                {null, JdbcType.INTEGER, Types.INTEGER},
+                {null, null, Types.OTHER},
+        });
+    }
+
+    private final PreparedStatement ps = mock(PreparedStatement.class);
+    private final Java8OptionalTypeHandler handler = new Java8OptionalTypeHandler();
+
+    private final Optional<Object> domainValue;
+    private final JdbcType jdbcType;
+    private final int statementType;
+
+    public SetNullParameterByIndexTest(Optional<Object> domainValue, JdbcType jdbcType, int statementType) {
+        this.domainValue = domainValue;
+        this.jdbcType = jdbcType;
+        this.statementType = statementType;
+    }
+
+    @Test
+    public void setsParametersAsExpected() throws SQLException {
+        int index = 5;
+
+        handler.setParameter(ps, index, domainValue, jdbcType);
+        verify(ps).setNull(index, statementType);
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/java8/SetParameterByIndexTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/optional/java8/SetParameterByIndexTest.java
@@ -1,0 +1,54 @@
+package com.loginbox.dropwizard.mybatis.types.optional.java8;
+
+import com.loginbox.dropwizard.mybatis.types.Java8OptionalTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class SetParameterByIndexTest {
+    @Parameters(name = "setParameter(..., {0}, {1}) binds to setObject(..., {2}, {3})")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {Optional.of("Hello"), JdbcType.VARCHAR, "Hello", Types.VARCHAR},
+                {Optional.of(5), JdbcType.INTEGER, 5, Types.INTEGER},
+                {Optional.of("Hello"), null, "Hello", Types.OTHER},
+        });
+    }
+
+    private final PreparedStatement ps = mock(PreparedStatement.class);
+    private final Java8OptionalTypeHandler handler = new Java8OptionalTypeHandler();
+
+    private final Optional<Object> domainValue;
+    private final JdbcType jdbcType;
+    private final Object statementValue;
+    private final int statementType;
+
+    public SetParameterByIndexTest(Optional<Object> domainValue, JdbcType jdbcType, Object statementValue, int statementType) {
+        this.domainValue = domainValue;
+        this.jdbcType = jdbcType;
+        this.statementValue = statementValue;
+        this.statementType = statementType;
+    }
+
+    @Test
+    public void setsParametersAsExpected() throws SQLException {
+        int index = 5;
+
+        handler.setParameter(ps, index, domainValue, jdbcType);
+        verify(ps).setObject(index, statementValue, statementType);
+    }
+}


### PR DESCRIPTION
Turns out MyBatis only sets the `JdbcType` params to non-`null` values if the
underlying mapper actually configures each parameter. The more likely case is
that the mapper is generic, and has no info about the `JdbcType`.

Surprise!

New testing strategy more or less care of @cyx.