### PR TITLE
Provide a request-scoped SqlSession.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,30 @@ _At present_, `MybatisBundle` doesn't provide any kind of automated transaction
 management. Applications are responsible for demarcating their own transactions
 using the session's `commit()` and `rollback()` methods.
 
+## Dependency Injection
+
+This bundle includes an injection provider for `SqlSession`, scoped to the
+current HTTP request:
+
+```java
+package com.example.helloworld.resources;
+
+@Path("/user/{username}")
+public class InjectionExampleResource {
+    @GET
+    public User getUser(
+        @PathParam("username") String username,
+        @Context SqlSession sqlSession) {
+
+        UsersMapper users = session.getMapper(UsersMapper.class);
+        return users.findByUsername(username);
+    }
+}
+```
+
+The session will be automatically closed at the end of the request. This does
+not provide automatic transaction management.
+
 ## Supported Types
 
 In addition to MyBatis' suite of built-in types, this bundle automatically

--- a/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
@@ -2,6 +2,7 @@ package com.loginbox.dropwizard.mybatis;
 
 import com.loginbox.dropwizard.mybatis.healthchecks.SqlSessionFactoryHealthCheck;
 import com.loginbox.dropwizard.mybatis.mappers.Ping;
+import com.loginbox.dropwizard.mybatis.providers.SqlSessionProvider;
 import com.loginbox.dropwizard.mybatis.types.GuavaOptionalTypeHandler;
 import com.loginbox.dropwizard.mybatis.types.Java8OptionalTypeHandler;
 import com.loginbox.dropwizard.mybatis.types.UuidTypeHandler;
@@ -194,6 +195,7 @@ public abstract class MybatisBundle<T extends io.dropwizard.Configuration> imple
         sqlSessionFactory = createSqlSessionFactory(dataSource);
 
         environment.healthChecks().register(name, new SqlSessionFactoryHealthCheck(sqlSessionFactory));
+        environment.jersey().register(SqlSessionProvider.binder(sqlSessionFactory));
     }
 
     private SqlSessionFactory createSqlSessionFactory(DataSource dataSource) throws Exception {

--- a/src/main/java/com/loginbox/dropwizard/mybatis/providers/SqlSessionProvider.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/providers/SqlSessionProvider.java
@@ -1,0 +1,56 @@
+package com.loginbox.dropwizard.mybatis.providers;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+/**
+ * Injection provider for {@link org.apache.ibatis.session.SqlSession}s. Using the default {@link
+ * #binder(org.apache.ibatis.session.SqlSessionFactory) binder}, this will provide an SqlSession scoped to an HTTP
+ * request, which will automatically be closed (and rolled back -- transactions are your problem) when the request
+ * completes.
+ */
+public class SqlSessionProvider implements Factory<SqlSession> {
+    public static class Binder extends AbstractBinder {
+        private final SqlSessionProvider sqlSessionProvider;
+
+        public Binder(SqlSessionFactory sqlSessionFactory) {
+            sqlSessionProvider = new SqlSessionProvider(sqlSessionFactory);
+        }
+
+        @Override
+        protected void configure() {
+            bindFactory(sqlSessionProvider).to(SqlSession.class).in(RequestScoped.class);
+        }
+    }
+
+    /**
+     * Given an SqlSessionFactory, provide SqlSessions from it for requests that need them.
+     *
+     * @param sqlSessionFactory
+     *         the factory to obtain sessions from.
+     * @return an HK2 binder providing an SqlSession for each request.
+     */
+    public static Binder binder(SqlSessionFactory sqlSessionFactory) {
+        return new Binder(sqlSessionFactory);
+    }
+
+    private final SqlSessionFactory sessionFactory;
+
+    public SqlSessionProvider(SqlSessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    public SqlSession provide() {
+        SqlSession sqlSession = sessionFactory.openSession();
+        return sqlSession;
+    }
+
+    @Override
+    public void dispose(SqlSession sqlSession) {
+        sqlSession.close();
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/MybatisBundleTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/MybatisBundleTest.java
@@ -3,9 +3,11 @@ package com.loginbox.dropwizard.mybatis;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.loginbox.dropwizard.mybatis.healthchecks.SqlSessionFactoryHealthCheck;
 import com.loginbox.dropwizard.mybatis.mappers.Ping;
+import com.loginbox.dropwizard.mybatis.providers.SqlSessionProvider;
 import com.loginbox.dropwizard.mybatis.testMappers.ExampleMapper;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import org.apache.ibatis.session.Configuration;
@@ -33,6 +35,7 @@ public class MybatisBundleTest {
     private final ManagedDataSource dataSource = mock(ManagedDataSource.class);
     private final LifecycleEnvironment lifecycle = mock(LifecycleEnvironment.class);
     private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
+    private final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
 
     private class TestMybatisBundle<T extends io.dropwizard.Configuration>
             extends MybatisBundle<T> {
@@ -58,6 +61,7 @@ public class MybatisBundleTest {
     public void wireMocks() {
         when(environment.lifecycle()).thenReturn(lifecycle);
         when(environment.healthChecks()).thenReturn(healthChecks);
+        when(environment.jersey()).thenReturn(jersey);
 
         when(dataSourceFactory.build(Matchers.any(), Matchers.any())).thenReturn(dataSource);
     }
@@ -90,6 +94,16 @@ public class MybatisBundleTest {
         bundle.run(configuration, environment);
 
         verify(healthChecks).register(anyString(), isA(SqlSessionFactoryHealthCheck.class));
+    }
+
+    @Test
+    public void registersProviders() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        verify(jersey).register(isA(SqlSessionProvider.Binder.class));
     }
 
     @Test

--- a/src/test/resources/com/loginbox/dropwizard/mybatis/providers/SqlSessionProviderTest.java
+++ b/src/test/resources/com/loginbox/dropwizard/mybatis/providers/SqlSessionProviderTest.java
@@ -1,0 +1,36 @@
+package com.loginbox.dropwizard.mybatis.providers;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SqlSessionProviderTest {
+    private final SqlSessionFactory sqlSessionFactory = mock(SqlSessionFactory.class);
+    private final SqlSessionProvider provider = new SqlSessionProvider(sqlSessionFactory);
+
+    private final SqlSession sqlSession = mock(SqlSession.class);
+
+    @Before
+    public void wireMocks() {
+        when(sqlSessionFactory.openSession()).thenReturn(sqlSession);
+    }
+
+    @Test
+    public void providesSessionFromFactory() {
+        assertThat(provider.provide(), is(sqlSession));
+    }
+
+    @Test
+    public void disposeClosesSession() {
+        provider.dispose(sqlSession);
+
+        verify(sqlSession).close();
+    }
+}


### PR DESCRIPTION
Unlike `dropwizard-hibernate`'s `@UnitOfWork` injection, this _only_ injects
the session. Transaction management is left up to the app.