### PR TITLE
Include default mappers for URIs and URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ management.
 In addition to MyBatis' suite of built-in types, this bundle automatically
 registers support for the following types:
 
+* `java.net.URL`
+* `java.net.URI`
 * `java.util.UUID`
 * `java.util.Optional`
 * `com.google.common.base.Optional`

--- a/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
@@ -5,6 +5,8 @@ import com.loginbox.dropwizard.mybatis.mappers.Ping;
 import com.loginbox.dropwizard.mybatis.providers.SqlSessionProvider;
 import com.loginbox.dropwizard.mybatis.types.GuavaOptionalTypeHandler;
 import com.loginbox.dropwizard.mybatis.types.Java8OptionalTypeHandler;
+import com.loginbox.dropwizard.mybatis.types.UriTypeHandler;
+import com.loginbox.dropwizard.mybatis.types.UrlTypeHandler;
 import com.loginbox.dropwizard.mybatis.types.UuidTypeHandler;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.db.DataSourceFactory;
@@ -21,6 +23,8 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
 
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
+import java.net.URI;
+import java.net.URL;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -218,6 +222,8 @@ public abstract class MybatisBundle<T extends io.dropwizard.Configuration> imple
         registry.register(UUID.class, new UuidTypeHandler());
         registry.register(java.util.Optional.class, new Java8OptionalTypeHandler());
         registry.register(com.google.common.base.Optional.class, new GuavaOptionalTypeHandler());
+        registry.register(URL.class, new UrlTypeHandler());
+        registry.register(URI.class, new UriTypeHandler());
     }
 
     private void registerClientMappers(Configuration configuration) {

--- a/src/main/java/com/loginbox/dropwizard/mybatis/types/UriTypeHandler.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/types/UriTypeHandler.java
@@ -1,0 +1,56 @@
+package com.loginbox.dropwizard.mybatis.types;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Maps {@link java.net.URI}s to the underlying database's character types.
+ */
+public class UriTypeHandler extends BaseTypeHandler<URI> {
+    /**
+     * Pass a UUID to the underlying statement's {@link java.sql.PreparedStatement#setObject(int, Object)} method. This
+     * relies on the JDBC driver to support UUIDs.
+     */
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, URI parameter, JdbcType jdbcType) throws SQLException {
+        String urlString = parameter.toString();
+        ps.setString(i, urlString);
+    }
+
+    @Override
+    public URI getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String urlString = rs.getString(columnName);
+        return coerceToUri(urlString);
+    }
+
+    @Override
+    public URI getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String urlString = rs.getString(columnIndex);
+        return coerceToUri(urlString);
+    }
+
+    @Override
+    public URI getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String urlString = cs.getString(columnIndex);
+        return coerceToUri(urlString);
+    }
+
+    private URI coerceToUri(String urlString) {
+        if (urlString == null)
+            return null;
+        try {
+            return new URI(urlString);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/main/java/com/loginbox/dropwizard/mybatis/types/UrlTypeHandler.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/types/UrlTypeHandler.java
@@ -1,0 +1,54 @@
+package com.loginbox.dropwizard.mybatis.types;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Maps {@link java.net.URL}s to the underlying database's character types.
+ */
+public class UrlTypeHandler extends BaseTypeHandler<URL> {
+    /**
+     * Pass a UUID to the underlying statement's {@link java.sql.PreparedStatement#setObject(int, Object)} method. This
+     * relies on the JDBC driver to support UUIDs.
+     */
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, URL parameter, JdbcType jdbcType) throws SQLException {
+        String urlString = parameter.toString();
+        ps.setString(i, urlString);
+    }
+
+    @Override
+    public URL getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String urlString = rs.getString(columnName);
+        return coerceToUrl(urlString);
+    }
+
+    @Override
+    public URL getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String urlString = rs.getString(columnIndex);
+        return coerceToUrl(urlString);
+    }
+
+    @Override
+    public URL getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String urlString = cs.getString(columnIndex);
+        return coerceToUrl(urlString);
+    }
+
+    private URL coerceToUrl(String urlString) {
+        if (urlString == null)
+            return null;
+        try {
+            return new URL(urlString);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/MybatisBundleTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/MybatisBundleTest.java
@@ -15,6 +15,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
 
+import java.net.URI;
+import java.net.URL;
 import java.util.UUID;
 
 import static com.loginbox.dropwizard.mybatis.matchers.ConfigurationMapperMatcher.hasMapper;
@@ -152,6 +154,30 @@ public class MybatisBundleTest {
         Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
 
         assertThat(configuration, hasTypeHandler(UUID.class));
+    }
+
+    @Test
+    public void registersUriType() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
+
+        assertThat(configuration, hasTypeHandler(URI.class));
+    }
+
+    @Test
+    public void registersUrlType() throws Exception {
+        MybatisBundle<io.dropwizard.Configuration> bundle
+                = new TestMybatisBundle<io.dropwizard.Configuration>();
+        bundle.initialize(bootstrap);
+        bundle.run(configuration, environment);
+
+        Configuration configuration = bundle.getSqlSessionFactory().getConfiguration();
+
+        assertThat(configuration, hasTypeHandler(URL.class));
     }
 
     @Test

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/UriTypeHandlerTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/UriTypeHandlerTest.java
@@ -1,0 +1,174 @@
+package com.loginbox.dropwizard.mybatis.types;
+
+import org.apache.ibatis.type.JdbcType;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UriTypeHandlerTest {
+    private final UriTypeHandler handler = new UriTypeHandler();
+
+    @Test
+    public void setsNonNullParameter() throws SQLException, URISyntaxException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        int index = 5;
+        URI url = new URI("http://www.example.com/");
+        JdbcType jdbcType = JdbcType.OTHER;
+
+        handler.setParameter(ps, index, url, jdbcType);
+
+        verify(ps).setString(index, "http://www.example.com/");
+    }
+
+    @Test
+    public void setsNullParameter() throws SQLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        int index = 5;
+        URI url = null;
+        JdbcType jdbcType = JdbcType.OTHER;
+
+        handler.setParameter(ps, index, url, jdbcType);
+
+        verify(ps).setNull(index, Types.OTHER);
+    }
+
+    @Test
+    public void readsNonNullResultByIndex() throws SQLException, URISyntaxException {
+        ResultSet rs = mock(ResultSet.class);
+        int index = 5;
+        URI expected = new URI("http://www.example.com/");
+
+        when(rs.getString(index)).thenReturn("http://www.example.com/");
+
+        URI result = handler.getResult(rs, index);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void readsNonUrlResultByIndex() throws SQLException, URISyntaxException {
+        ResultSet rs = mock(ResultSet.class);
+        int index = 5;
+
+        when(rs.getString(index)).thenReturn("a banana");
+
+        try{
+            handler.getResult(rs, index);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getCause(), is(instanceOf(URISyntaxException.class)));
+        }
+    }
+
+    @Test
+    public void readsNullResultByIndex() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        int index = 5;
+
+        when(rs.getString(index)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+
+        URI result = handler.getResult(rs, index);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void readsNonNullResultByName() throws SQLException, URISyntaxException {
+        ResultSet rs = mock(ResultSet.class);
+        String column = "column name";
+        URI expected = new URI("http://www.example.com/");
+
+        when(rs.getString(column)).thenReturn("http://www.example.com/");
+
+        URI result = handler.getResult(rs, column);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void readsNonUrlResultByName() throws SQLException, URISyntaxException {
+        ResultSet rs = mock(ResultSet.class);
+        String column = "column name";
+
+        when(rs.getString(column)).thenReturn("a banana");
+
+        try{
+            handler.getResult(rs, column);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getCause(), is(instanceOf(URISyntaxException.class)));
+        }
+    }
+
+    @Test
+    public void readsNullResultByName() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        String column = "column name";
+
+        when(rs.getObject(column)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+
+        URI result = handler.getResult(rs, column);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void readsNonNullCallableResult() throws SQLException, URISyntaxException {
+        CallableStatement cs = mock(CallableStatement.class);
+        int index = 5;
+        URI expected = new URI("http://www.example.com/");
+
+        when(cs.getString(index)).thenReturn("http://www.example.com/");
+
+        URI result = handler.getResult(cs, index);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void readsNonUrlCallableResult() throws SQLException, URISyntaxException {
+        CallableStatement cs = mock(CallableStatement.class);
+        int index = 5;
+
+        when(cs.getString(index)).thenReturn("a banana");
+
+        try{
+            handler.getResult(cs, index);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getCause(), is(instanceOf(URISyntaxException.class)));
+        }
+    }
+
+    @Test
+    public void readsNullCallableResult() throws SQLException {
+        CallableStatement cs = mock(CallableStatement.class);
+        int index = 5;
+
+        when(cs.getString(index)).thenReturn(null);
+        when(cs.wasNull()).thenReturn(true);
+
+        URI result = handler.getResult(cs, index);
+
+        assertThat(result, is(nullValue()));
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/UrlTypeHandlerTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/UrlTypeHandlerTest.java
@@ -1,0 +1,173 @@
+package com.loginbox.dropwizard.mybatis.types;
+
+import org.apache.ibatis.type.JdbcType;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UrlTypeHandlerTest {
+    private final UrlTypeHandler handler = new UrlTypeHandler();
+
+    @Test
+    public void setsNonNullParameter() throws SQLException, MalformedURLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        int index = 5;
+        URL url = new URL("http://www.example.com/");
+        JdbcType jdbcType = JdbcType.OTHER;
+
+        handler.setParameter(ps, index, url, jdbcType);
+
+        verify(ps).setString(index, "http://www.example.com/");
+    }
+
+    @Test
+    public void setsNullParameter() throws SQLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        int index = 5;
+        URL url = null;
+        JdbcType jdbcType = JdbcType.OTHER;
+
+        handler.setParameter(ps, index, url, jdbcType);
+
+        verify(ps).setNull(index, Types.OTHER);
+    }
+
+    @Test
+    public void readsNonNullResultByIndex() throws SQLException, MalformedURLException {
+        ResultSet rs = mock(ResultSet.class);
+        int index = 5;
+        URL expected = new URL("http://www.example.com/");
+
+        when(rs.getString(index)).thenReturn("http://www.example.com/");
+
+        URL result = handler.getResult(rs, index);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void readsNullResultByIndex() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        int index = 5;
+
+        when(rs.getString(index)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+
+        URL result = handler.getResult(rs, index);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void readsNonNullResultByName() throws SQLException, MalformedURLException {
+        ResultSet rs = mock(ResultSet.class);
+        String column = "column name";
+        URL expected = new URL("http://www.example.com/");
+
+        when(rs.getString(column)).thenReturn("http://www.example.com/");
+
+        URL result = handler.getResult(rs, column);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void readsNonUrlResultByIndex() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        int index = 5;
+
+        when(rs.getString(index)).thenReturn("a banana");
+
+        try{
+            handler.getResult(rs, index);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getCause(), is(instanceOf(MalformedURLException.class)));
+        }
+    }
+
+    @Test
+    public void readsNonUrlResultByName() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        String column = "column name";
+
+        when(rs.getString(column)).thenReturn("a banana");
+
+        try{
+            handler.getResult(rs, column);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getCause(), is(instanceOf(MalformedURLException.class)));
+        }
+    }
+
+    @Test
+    public void readsNullResultByName() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        String column = "column name";
+
+        when(rs.getObject(column)).thenReturn(null);
+        when(rs.wasNull()).thenReturn(true);
+
+        URL result = handler.getResult(rs, column);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void readsNonNullCallableResult() throws SQLException, MalformedURLException {
+        CallableStatement cs = mock(CallableStatement.class);
+        int index = 5;
+        URL expected = new URL("http://www.example.com/");
+
+        when(cs.getString(index)).thenReturn("http://www.example.com/");
+
+        URL result = handler.getResult(cs, index);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void readsNonUrlCallableResult() throws SQLException {
+        CallableStatement cs = mock(CallableStatement.class);
+        int index = 5;
+
+        when(cs.getString(index)).thenReturn("a banana");
+
+        try{
+            handler.getResult(cs, index);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getCause(), is(instanceOf(MalformedURLException.class)));
+        }
+    }
+
+    @Test
+    public void readsNullCallableResult() throws SQLException {
+        CallableStatement cs = mock(CallableStatement.class);
+        int index = 5;
+
+        when(cs.getString(index)).thenReturn(null);
+        when(cs.wasNull()).thenReturn(true);
+
+        URL result = handler.getResult(cs, index);
+
+        assertThat(result, is(nullValue()));
+    }
+}

--- a/src/test/java/com/loginbox/dropwizard/mybatis/types/UuidTypeHandlerTest.java
+++ b/src/test/java/com/loginbox/dropwizard/mybatis/types/UuidTypeHandlerTest.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,14 +63,13 @@ public class UuidTypeHandlerTest {
     public void readsNullResultByIndex() throws SQLException {
         ResultSet rs = mock(ResultSet.class);
         int index = 5;
-        UUID expected = null;
 
-        when(rs.getObject(index)).thenReturn(expected);
+        when(rs.getObject(index)).thenReturn(null);
         when(rs.wasNull()).thenReturn(true);
 
         UUID result = handler.getResult(rs, index);
 
-        assertThat(result, is(expected));
+        assertThat(result, is(nullValue()));
     }
 
     @Test
@@ -89,14 +89,13 @@ public class UuidTypeHandlerTest {
     public void readsNullResultByName() throws SQLException {
         ResultSet rs = mock(ResultSet.class);
         String column = "column name";
-        UUID expected = null;
 
-        when(rs.getObject(column)).thenReturn(expected);
+        when(rs.getObject(column)).thenReturn(null);
         when(rs.wasNull()).thenReturn(true);
 
         UUID result = handler.getResult(rs, column);
 
-        assertThat(result, is(expected));
+        assertThat(result, is(nullValue()));
     }
 
     @Test
@@ -116,13 +115,12 @@ public class UuidTypeHandlerTest {
     public void readsNullCallableResult() throws SQLException {
         CallableStatement cs = mock(CallableStatement.class);
         int index = 5;
-        UUID expected = null;
 
         when(cs.getObject(index)).thenReturn(null);
         when(cs.wasNull()).thenReturn(true);
 
         UUID result = handler.getResult(cs, index);
 
-        assertThat(result, is(expected));
+        assertThat(result, is(nullValue()));
     }
 }


### PR DESCRIPTION
These arise in webapps, which is the target of any Dropwizard extension such as
this. Handle them sensibly by default, without additional configuration.