### PR TITLE
Update to Dropwizard 0.9.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Build Status](https://circleci.com/gh/login-box/dropwizard-mybatis.svg)](https://circleci.com/gh/login-box/dropwizard-mybatis)
 
+## Dropwizard Versions
+
+Versions up to `0.2.0` are compatible with Dropwizard 0.8.x.
+Versions from `1.0.0` upward are compatible with Dropwizard 0.9.x.
+
 ## Installing
 
 All modules are hosted on Bintray's JCenter repository.

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     ext {
-        dropwizardVersion = '0.8.0'
+        dropwizardVersion = '0.9.1'
 
         mybatisVersion = '3.2.8'
 

--- a/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
+++ b/src/main/java/com/loginbox/dropwizard/mybatis/MybatisBundle.java
@@ -9,9 +9,9 @@ import com.loginbox.dropwizard.mybatis.types.UriTypeHandler;
 import com.loginbox.dropwizard.mybatis.types.UrlTypeHandler;
 import com.loginbox.dropwizard.mybatis.types.UuidTypeHandler;
 import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.DatabaseConfiguration;
 import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Bootstrap;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
@@ -235,14 +235,16 @@ public abstract class MybatisBundle<T extends io.dropwizard.Configuration> imple
     }
 
     private ManagedDataSource buildDataSource(T configuration, io.dropwizard.setup.Environment environment) {
-        DataSourceFactory dataSourceFactory = getDataSourceFactory(configuration);
+        PooledDataSourceFactory dataSourceFactory = getDataSourceFactory(configuration);
         return dataSourceFactory.build(environment.metrics(), name);
     }
 
-    private <T> Consumer<Configuration> configure(BiConsumer<Configuration, T> valueApplicator, T value, T... values) {
+    /* @SafeVarargs would be appropriate, but it's not permitted on private methods until Java 9. */
+    @SuppressWarnings("unchecked")
+    private <V> Consumer<Configuration> configure(BiConsumer<Configuration, V> valueApplicator, V value, V... values) {
         return (configuration) -> {
             valueApplicator.accept(configuration, value);
-            for (T v : values) {
+            for (V v : values) {
                 valueApplicator.accept(configuration, v);
             }
         };


### PR DESCRIPTION
* Clear version rules in the README.
* Fix compatibility errors around the DataSource to PooledDataSource switchover.
* Fix some warnings, because why not.

This change is not backwards-compatible.